### PR TITLE
Bot auf Kommentare mit zusätzlichem Text reagieren lassen

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,9 +34,7 @@ async function main() {
 
     watcher.start(async () => {
       const Comments = await api.messages.getComments();
-      const messages = Comments.messages.filter((msg) => {
-        return msg.read == 0 && (msg.message == "@Sauce" || msg.message == "@sauce");
-      })
+      const messages = Comments.messages.filter(msg => msg.read == 0 && msg.message.toLowerCase().includes("@sauce"));
       messages.forEach(async msg => {
         q.push(async () => {
           const thumb = await pr0.resolveThumb(msg.thumb); //Hole mir die original URL zu dem Video


### PR DESCRIPTION
Hier aufgefallen, dass der Bot nur auf Kommentare reagiert, die ausschließlich `@Sauce` beinhalten: https://pr0gramm.com/top/4687007:comment50228974

Sinnvoll wäre es wohl, dass er auch dann reagiert, wenn zusätzlicher Text dabei ist.